### PR TITLE
Fix case mismatch issue

### DIFF
--- a/judge/handler.py
+++ b/judge/handler.py
@@ -984,13 +984,13 @@ def process_comment(problem_id: str, person_id: str, commenter_id: str,
     person = models.Person.objects.filter(email=person_id.lower())
     if not person.exists():
         return (False,
-                ValidationError('Person with primary key = {} not found'.format(person_id.lower())))
+                ValidationError('Person with email = {} not found'.format(person_id.lower())))
     person = person[0]
 
     commenter = models.Person.objects.filter(email=commenter_id.lower())
     if not commenter.exists():
         return (False,
-                ValidationError('Person with primary key = {} not found'.format(commenter_id.lower())))
+                ValidationError('Person with email = {} not found'.format(commenter_id.lower())))
     commenter = commenter[0]
 
     try:


### PR DESCRIPTION
Addressing bug report:

- Case mismatch between participant list email addresses and login email ids causes validation for private contests to fail.
Eg: cs15btech11043@iith.ac.in cannot see a private contest even though CS15BTECH11043@iith.ac.in exists in the participant list. Is this intended behaviour?
