### PR TITLE
Fix leaderboard bug

### DIFF
--- a/judge/handler.py
+++ b/judge/handler.py
@@ -798,7 +798,6 @@ def get_personcontest_score(person_id: str,
 
     problems = models.Problem.objects.filter(contest=contest)
     full_filter = Q()
-    full_filter |= Q(person=person)
     for problem in problems:
         full_filter |= Q(person=person, problem=problem)
 


### PR DESCRIPTION
Addressing bug report:

- The scores displayed in the contest leaderboard is a sum of scores of all contests! Shouldn't the contest leaderboard score be specific to that particular contest?!