### PR TITLE
Fix ASCII issue with compilation

### DIFF
--- a/content/main_compiler.sh
+++ b/content/main_compiler.sh
@@ -21,6 +21,10 @@ SUB_FILE=$2
 
 . ${PROB_FDR}/${PROB_CODE}/compilation_script.sh
 
+if ! file $SUBPATH | grep -i -q "ascii" ; then  # checking for ASCII source files
+    return $FAILURE
+fi
+
 # Now perform string-matching to get the extension
 # and the corresponding "executable"
 SUBPATH=${SUB_FDR}/${SUB_FILE}
@@ -57,5 +61,5 @@ case "$SUBPATH" in
         ;;
 esac
 
-# Return the return value of the 
+# Return the status of compilation
 return $?

--- a/content/main_compiler.sh
+++ b/content/main_compiler.sh
@@ -21,7 +21,7 @@ SUB_FILE=$2
 
 . ${PROB_FDR}/${PROB_CODE}/compilation_script.sh
 
-if ! file $SUBPATH | grep -i -q "ascii" ; then  # checking for ASCII source files
+if [[ ! "$(file --mime -b ${SUBPATH})" =~ 'ascii'$ ]] ; then  # checking for ASCII source files
     return $FAILURE
 fi
 

--- a/content/main_compiler.sh
+++ b/content/main_compiler.sh
@@ -21,7 +21,7 @@ SUB_FILE=$2
 
 . ${PROB_FDR}/${PROB_CODE}/compilation_script.sh
 
-if [[ ! "$(file --mime -b ${SUBPATH})" =~ 'ascii'$ ]] ; then  # checking for ASCII source files
+if ! file --mime -b ${SUBPATH} | grep -i -q "ascii" ; then  # checking for ASCII source files
     return $FAILURE
 fi
 


### PR DESCRIPTION
Addressing bug report:

- A student uploaded a file that had emoticons and stuff in it. The file was Unicode. This caused a crash in a location where an exception was not even imagined to occur. So there was no exception caught.